### PR TITLE
Avoid unnecessary use of eval (insecure)

### DIFF
--- a/OPSI/System/Posix.py
+++ b/OPSI/System/Posix.py
@@ -1565,7 +1565,7 @@ class Harddisk:  # pylint: disable=too-many-instance-attributes,too-many-public-
 					part_id = "07"
 				else:
 					raise ValueError(f"Partition type '{part_id}' not supported!")
-			part_id = eval("0x" + part_id)  # pylint: disable=eval-used
+			part_id = int(part_id, 16)
 			offset = 0x1BE + (partition - 1) * 16 + 4
 			with open(self.device, "rb+") as file:
 				file.seek(offset)


### PR DESCRIPTION
The appropriate way to convert a hexadecimal string to integer is by using the built-in functionality of `int`. The `eval` function is insecure; if the input could possibly come from outside the program, no matter how indirectly, this creates a risk of an arbitrary code execution exploit. It's also much less efficient.